### PR TITLE
add TryStart to get a list of successfully started dependencies

### DIFF
--- a/startstop.go
+++ b/startstop.go
@@ -40,14 +40,17 @@ type Logger interface {
 	Errorf(f string, args ...interface{})
 }
 
-// Start the graph, in the right order. Start will call Start or Open if an
-// object satisfies the associated interface.
-func Start(objects []*inject.Object, log Logger) error {
+// TryStart will start the graph, in the right order. It will call
+// Start or Open. It returns the list of objects that have been
+// successfully started. This can be used to stop only the
+// dependencies that have been correctly started.
+func TryStart(objects []*inject.Object, log Logger) ([]*inject.Object, error) {
 	levels, err := levels(objects)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
+	var started []*inject.Object
 	for i := len(levels) - 1; i >= 0; i-- {
 		level := levels[i]
 		for _, o := range level {
@@ -56,7 +59,7 @@ func Start(objects []*inject.Object, log Logger) error {
 					log.Debugf("opening %s", o)
 				}
 				if err := openerO.Open(); err != nil {
-					return err
+					return started, err
 				}
 			}
 			if starterO, ok := o.Value.(Starter); ok {
@@ -64,12 +67,20 @@ func Start(objects []*inject.Object, log Logger) error {
 					log.Debugf("starting %s", o)
 				}
 				if err := starterO.Start(); err != nil {
-					return err
+					return started, err
 				}
 			}
+			started = append(started, o)
 		}
 	}
-	return nil
+	return started, nil
+}
+
+// Start the graph, in the right order. Start will call Start or Open if an
+// object satisfies the associated interface.
+func Start(objects []*inject.Object, log Logger) error {
+	_, err := TryStart(objects, log)
+	return err
 }
 
 // Stop the graph, in the right order. Stop will call Stop or Close if an


### PR DESCRIPTION
This enables a user to call Stop on the returned list of dependencies to
be able to cleanup correctly in case of errors on start.

Fix #2.
